### PR TITLE
Run finally tests also on 5.6.x

### DIFF
--- a/t/context.t
+++ b/t/context.t
@@ -52,19 +52,11 @@ sub run {
     return 'catch';
   }
   finally {
-    SKIP: {
-      skip "DESTROY() not called in void context on perl $]", 1
-        if "$]" < '5.008';
-      is (wantarray, undef, "Proper VOID context in finally{} 1");
-    }
+    is (wantarray, undef, "Proper VOID context in finally{} 1");
     return 'finally';
   }
   finally {
-    SKIP: {
-      skip "DESTROY() not called in void context on perl $]", 1
-        if "$]" < '5.008';
-      is (wantarray, undef, "Proper VOID context in finally{} 2");
-    }
+    is (wantarray, undef, "Proper VOID context in finally{} 2");
     return 'finally';
   };
 }


### PR DESCRIPTION
Skip for those tests was added in commit 2531688ce109de57a8e170677240a17df3f8528e.
But fix for calling finally {} in VOID context also for 5.6.x was added in commit
5f5e92c0e36725a449c010c445eba40589ac8bf6, so there is no need to skip those tests.