### PR TITLE
Add information about Try::Catch into SEE ALSO section

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -443,6 +443,10 @@ is unclear whether the new version 18 behavior is final.
 Much more feature complete, more convenient semantics, but at the cost of
 implementation complexity.
 
+=item L<Try::Catch>
+
+Much faster re-implementation of C<Try::Tiny> without C<finally> support.
+
 =item L<autodie>
 
 Automatic error throwing for builtin functions and more. Also designed to

--- a/lib/Try/Tiny.pm
+++ b/lib/Try/Tiny.pm
@@ -633,6 +633,10 @@ is unclear whether the new version 18 behavior is final.
 Much more feature complete, more convenient semantics, but at the cost of
 implementation complexity.
 
+=item L<Try::Catch>
+
+Much faster re-implementation of C<Try::Tiny> without C<finally> support.
+
 =item L<autodie>
 
 Automatic error throwing for builtin functions and more. Also designed to


### PR DESCRIPTION
I think that lightweight and faster re-implementation of Try::Tiny can be useful for more people and SEE ALSO section is good place to mention it.

@mamod (as author of Try::Catch): Are you fine with this? Currently you still specify `finally` support in documentation, but also with information `it's planned to be removed in v2.0.0`.