### PR TITLE
Fix warning on 5.8

### DIFF
--- a/lib/Try/Tiny.pm
+++ b/lib/Try/Tiny.pm
@@ -70,7 +70,7 @@ sub try (&;@) {
   # $catch->();
 
   # name the blocks if we have Sub::Name installed
-  _subname(caller.'::try {...} ' => $try)
+  _subname(caller().'::try {...} ' => $try)
     if _HAS_SUBNAME;
 
   # set up scope guards to invoke the finally blocks at the end.
@@ -139,7 +139,7 @@ sub catch (&;@) {
 
   croak 'Useless bare catch()' unless wantarray;
 
-  _subname(caller.'::catch {...} ' => $block)
+  _subname(caller().'::catch {...} ' => $block)
     if _HAS_SUBNAME;
   return (
     bless(\$block, 'Try::Tiny::Catch'),
@@ -152,7 +152,7 @@ sub finally (&;@) {
 
   croak 'Useless bare finally()' unless wantarray;
 
-  _subname(caller.'::finally {...} ' => $block)
+  _subname(caller().'::finally {...} ' => $block)
     if _HAS_SUBNAME;
   return (
     bless(\$block, 'Try::Tiny::Finally'),


### PR DESCRIPTION
I caused this problem with my last PR. Pre-5.10 Perl doesn’t like `caller` without parens.