### PR TITLE
Use optional module Scope::Cleanup for trapping exceptions from the finally block

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ copy_to = develop.requires
 module = Capture::Tiny  ; capture_stderr
 module = Sub::Name
 module = Sub::Util
+module = Scope::Cleanup
 
 [OnlyCorePrereqs]
 check_dual_life_versions = 0


### PR DESCRIPTION
Currently throwing exception from the finally block show just:

Execution of finally() block $code resulted in an exception, which
*CAN NOT BE PROPAGATED* due to fundamental limitations of Perl.

This patch implements throwing exceptions form the finally block via
optional module Scope::Cleanup. When module is not installed then Try::Tiny
would show same message as before. When installed, then it cleanup will
rethrow exception from finally block back to the caller.

There is also a new test which check that finally blocks are always called
in same order as before this patch.